### PR TITLE
Fix server vote creation validation for date inputs

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,8 +26,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post('/api/votes', isAuthenticated, async (req: any, res) => {
     try {
       const userId = req.user.claims.sub;
+
+      const startDate = new Date(req.body.startDate);
+      const endDate = new Date(req.body.endDate);
+
+      if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+        return res.status(400).json({ message: "Invalid vote dates provided" });
+      }
+
       const voteData = insertVoteSchema.parse({
         ...req.body,
+        startDate,
+        endDate,
         createdBy: userId,
       });
       


### PR DESCRIPTION
## Summary
- parse incoming start and end dates before validating vote creation payloads
- return a clear 400 response when invalid date values are supplied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e516fef32c83249aad70aadb589c91