### PR TITLE
Invalidate active votes query after creating a vote

### DIFF
--- a/client/src/pages/create-vote.tsx
+++ b/client/src/pages/create-vote.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -33,6 +33,7 @@ export default function CreateVote() {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
   const [options, setOptions] = useState(['', '']);
+  const queryClient = useQueryClient();
 
   const form = useForm<VoteFormData>({
     resolver: zodResolver(voteSchema),
@@ -61,6 +62,7 @@ export default function CreateVote() {
       return await apiRequest('POST', '/api/votes', voteData);
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/votes/active'] });
       toast({
         title: "Vote Created",
         description: "Your vote has been created successfully and is now active.",


### PR DESCRIPTION
## Summary
- invalidate the active votes query after a new vote is created so the dashboard refreshes
- obtain the React Query client in the create vote page to perform the invalidation

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68e5192d0ec48324922499484b063275