### PR TITLE
Add attendance tracking features

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,9 @@ import CreateVote from "@/pages/create-vote";
 import VoteSession from "@/pages/vote-session";
 import Results from "@/pages/results";
 import Archive from "@/pages/archive";
+import Attendance from "@/pages/attendance";
+import CreateAttendance from "@/pages/create-attendance";
+import AttendanceSessionPage from "@/pages/attendance-session";
 
 function Router() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -26,6 +29,9 @@ function Router() {
           <Route path="/vote/:id" component={VoteSession} />
           <Route path="/results/:id" component={Results} />
           <Route path="/archive" component={Archive} />
+          <Route path="/attendance" component={Attendance} />
+          <Route path="/create-attendance" component={CreateAttendance} />
+          <Route path="/attendance/:id" component={AttendanceSessionPage} />
         </>
       )}
       <Route component={NotFound} />

--- a/client/src/components/attendance-card.tsx
+++ b/client/src/components/attendance-card.tsx
@@ -1,0 +1,154 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+import { apiRequest } from "@/lib/queryClient";
+import { CalendarDays, CheckCircle2, ClipboardList } from "lucide-react";
+import type { AttendanceSession, AttendanceRecord, User } from "@shared/schema";
+
+interface AttendanceSummary {
+  counts: Record<string, number>;
+  records: Array<{
+    id: string;
+    response: 'present' | 'excused' | 'absent';
+  }>;
+}
+
+interface AttendanceCardProps {
+  session: AttendanceSession & {
+    creator?: Pick<User, "firstName" | "lastName"> | null;
+  };
+}
+
+const formatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "full",
+  timeStyle: "short",
+});
+
+export function AttendanceCard({ session }: AttendanceCardProps) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth() as { user: User | undefined };
+
+  const { data: myRecord } = useQuery<AttendanceRecord | null>({
+    queryKey: [`/api/attendance/${session.id}/my-record`],
+    enabled: !!session.id,
+  });
+
+  const { data: summary } = useQuery<AttendanceSummary>({
+    queryKey: [`/api/attendance/${session.id}/summary`],
+    enabled: !!session.id,
+  });
+
+  const markAttendanceMutation = useMutation({
+    mutationFn: async (response: "present" | "excused" | "absent") => {
+      const res = await apiRequest('POST', `/api/attendance/${session.id}/mark`, {
+        response,
+      });
+      return await res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/attendance/${session.id}/my-record`] });
+      queryClient.invalidateQueries({ queryKey: [`/api/attendance/${session.id}/summary`] });
+    },
+  });
+
+  const meetingDateLabel = useMemo(() => formatter.format(new Date(session.meetingDate)), [session.meetingDate]);
+
+  const response = myRecord?.response;
+  const counts = summary?.counts ?? { total: 0, present: 0, excused: 0, absent: 0 };
+
+  const organiserName = session.creator
+    ? `${session.creator.firstName ?? ''} ${session.creator.lastName ?? ''}`.trim() || 'Chapter leadership'
+    : 'Chapter leadership';
+
+  return (
+    <Card className="hover-lift overflow-hidden" data-testid={`card-attendance-${session.id}`}>
+      {response && (
+        <div className="bg-secondary/10 px-4 py-2 flex items-center gap-2">
+          <CheckCircle2 className="text-secondary" size={16} />
+          <span className="text-sm font-medium text-secondary-foreground capitalize">
+            You marked {response}
+          </span>
+        </div>
+      )}
+
+      <CardContent className="p-6 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="bg-primary/10 text-primary border-primary/20 capitalize">
+                {session.status}
+              </Badge>
+              <Badge variant="secondary" className="flex items-center gap-1">
+                <CalendarDays size={14} />
+                {meetingDateLabel}
+              </Badge>
+            </div>
+            <h4 className="text-lg font-semibold text-foreground" data-testid={`text-attendance-title-${session.id}`}>
+              {session.title}
+            </h4>
+            <p className="text-sm text-muted-foreground" data-testid={`text-attendance-description-${session.id}`}>
+              {session.description || 'No description provided'}
+            </p>
+            <p className="text-xs text-muted-foreground">Organised by {organiserName}</p>
+          </div>
+          <Link href={`/attendance/${session.id}`}>
+            <Button variant="outline" size="sm" className="flex items-center gap-2">
+              <ClipboardList size={14} />
+              View Details
+            </Button>
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3 text-center">
+          <div className="border border-border rounded-lg p-3">
+            <p className="text-xs text-muted-foreground">Present</p>
+            <p className="text-lg font-semibold text-foreground">{counts.present ?? 0}</p>
+          </div>
+          <div className="border border-border rounded-lg p-3">
+            <p className="text-xs text-muted-foreground">Excused</p>
+            <p className="text-lg font-semibold text-foreground">{counts.excused ?? 0}</p>
+          </div>
+          <div className="border border-border rounded-lg p-3">
+            <p className="text-xs text-muted-foreground">Absent</p>
+            <p className="text-lg font-semibold text-foreground">{counts.absent ?? 0}</p>
+          </div>
+        </div>
+
+        {session.status === 'open' && user?.id && (
+          <div className="flex flex-col sm:flex-row gap-3">
+            <Button
+              className="flex-1"
+              data-testid={`button-attendance-present-${session.id}`}
+              disabled={markAttendanceMutation.isPending}
+              onClick={() => markAttendanceMutation.mutate('present')}
+            >
+              I'm Present
+            </Button>
+            <Button
+              variant="secondary"
+              className="flex-1"
+              data-testid={`button-attendance-excused-${session.id}`}
+              disabled={markAttendanceMutation.isPending}
+              onClick={() => markAttendanceMutation.mutate('excused')}
+            >
+              Excused
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-1"
+              data-testid={`button-attendance-absent-${session.id}`}
+              disabled={markAttendanceMutation.isPending}
+              onClick={() => markAttendanceMutation.mutate('absent')}
+            >
+              Absent
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/navigation-header.tsx
+++ b/client/src/components/navigation-header.tsx
@@ -3,7 +3,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { Vote, Home, Archive, Users, Plus, ChevronDown } from "lucide-react";
+import { Vote, Home, Archive, Users, Plus, ChevronDown, CalendarCheck } from "lucide-react";
 import type { User } from "@shared/schema";
 
 export function NavigationHeader() {
@@ -31,16 +31,24 @@ export function NavigationHeader() {
           
           {/* Navigation */}
           <nav className="hidden md:flex items-center gap-6">
-            <Link 
-              href="/" 
+            <Link
+              href="/"
               className={`text-foreground hover:text-primary font-medium transition-colors flex items-center gap-2 ${location === '/' ? 'text-primary' : ''}`}
               data-testid="link-dashboard"
             >
               <Home size={16} />
               Dashboard
             </Link>
-            <Link 
-              href="/archive" 
+            <Link
+              href="/attendance"
+              className={`text-muted-foreground hover:text-primary font-medium transition-colors flex items-center gap-2 ${location === '/attendance' ? 'text-primary' : ''}`}
+              data-testid="link-attendance"
+            >
+              <CalendarCheck size={16} />
+              Attendance
+            </Link>
+            <Link
+              href="/archive"
               className={`text-muted-foreground hover:text-primary font-medium transition-colors flex items-center gap-2 ${location === '/archive' ? 'text-primary' : ''}`}
               data-testid="link-archive"
             >
@@ -66,7 +74,7 @@ export function NavigationHeader() {
                 <Avatar className="w-9 h-9">
                   <AvatarImage src={user?.profileImageUrl ? user.profileImageUrl : undefined} />
                   <AvatarFallback className="bg-secondary text-secondary-foreground font-semibold text-sm">
-                    {getInitials(user?.firstName, user?.lastName)}
+                    {getInitials(user?.firstName ?? undefined, user?.lastName ?? undefined)}
                   </AvatarFallback>
                 </Avatar>
                 <div className="hidden md:block text-left">
@@ -84,6 +92,12 @@ export function NavigationHeader() {
                   <Link href="/create-vote" className="md:hidden" data-testid="link-create-vote-mobile">
                     <Plus size={16} className="mr-2" />
                     Create Vote
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/create-attendance" data-testid="link-create-attendance">
+                    <CalendarCheck size={16} className="mr-2" />
+                    Create Attendance
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator className="md:hidden" />

--- a/client/src/pages/attendance-session.tsx
+++ b/client/src/pages/attendance-session.tsx
@@ -1,0 +1,283 @@
+import { useParams, useLocation } from "wouter";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { NavigationHeader } from "@/components/navigation-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import { CalendarDays, CheckCircle2, UserRound } from "lucide-react";
+import { useState } from "react";
+import type { AttendanceSession, AttendanceRecord, User } from "@shared/schema";
+
+interface AttendanceSessionResponse {
+  session: AttendanceSession;
+  creator?: Pick<User, "firstName" | "lastName" | "email"> | null;
+}
+
+interface AttendanceSummaryRecord {
+  id: string;
+  userId: string;
+  response: 'present' | 'excused' | 'absent';
+  note: string | null;
+  recordedAt: string;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+}
+
+interface AttendanceSummary {
+  counts: Record<string, number>;
+  records: AttendanceSummaryRecord[];
+}
+
+export default function AttendanceSessionPage() {
+  const { id } = useParams<{ id: string }>();
+  const [, setLocation] = useLocation();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [note, setNote] = useState("");
+
+  const { data: sessionDetails, isLoading, error } = useQuery<AttendanceSessionResponse>({
+    queryKey: [`/api/attendance/${id}`],
+    enabled: !!id,
+  });
+
+  const { data: myRecord } = useQuery<AttendanceRecord | null>({
+    queryKey: [`/api/attendance/${id}/my-record`],
+    enabled: !!id,
+  });
+
+  const { data: summary } = useQuery<AttendanceSummary>({
+    queryKey: [`/api/attendance/${id}/summary`],
+    enabled: !!id,
+  });
+
+  const updateStatusMutation = useMutation({
+    mutationFn: async (status: 'scheduled' | 'open' | 'closed') => {
+      await apiRequest('PATCH', `/api/attendance/${id}/status`, { status });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/attendance/${id}`] });
+      queryClient.invalidateQueries({ queryKey: ['/api/attendance/status/open'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/attendance/status/scheduled'] });
+    },
+    onError: (err: Error) => {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to update status",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const markAttendanceMutation = useMutation({
+    mutationFn: async (response: 'present' | 'excused' | 'absent') => {
+      const res = await apiRequest('POST', `/api/attendance/${id}/mark`, { response, note: note.trim() || undefined });
+      return await res.json();
+    },
+    onSuccess: () => {
+      toast({
+        title: "Attendance updated",
+        description: "Your attendance response has been recorded.",
+      });
+      queryClient.invalidateQueries({ queryKey: [`/api/attendance/${id}/my-record`] });
+      queryClient.invalidateQueries({ queryKey: [`/api/attendance/${id}/summary`] });
+      setNote("");
+    },
+    onError: (err: Error) => {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to update attendance",
+        variant: "destructive",
+      });
+    },
+  });
+
+  if (!id) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <NavigationHeader />
+        <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 text-center text-muted-foreground">
+          Loading attendance session...
+        </main>
+      </div>
+    );
+  }
+
+  if (error || !sessionDetails) {
+    return (
+      <div className="min-h-screen bg-background">
+        <NavigationHeader />
+        <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 text-center space-y-4">
+          <p className="text-lg font-semibold text-foreground">Attendance session not found.</p>
+          <Button variant="outline" onClick={() => setLocation('/attendance')}>
+            Go back to attendance dashboard
+          </Button>
+        </main>
+      </div>
+    );
+  }
+
+  const { session, creator } = sessionDetails;
+  const meetingDate = new Date(session.meetingDate);
+  const formattedDate = new Intl.DateTimeFormat(undefined, { dateStyle: 'full', timeStyle: 'short' }).format(meetingDate);
+  const myResponse = myRecord?.response;
+  const counts = summary?.counts ?? { total: 0, present: 0, excused: 0, absent: 0 };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationHeader />
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div className="space-y-2">
+            <Badge variant="outline" className="bg-primary/10 text-primary border-primary/20 capitalize w-fit">
+              {session.status}
+            </Badge>
+            <h1 className="text-3xl font-bold text-foreground">{session.title}</h1>
+            <p className="text-muted-foreground">{session.description || 'No description provided.'}</p>
+            <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <CalendarDays size={16} />
+                {formattedDate}
+              </span>
+              <span className="flex items-center gap-2">
+                <UserRound size={16} />
+                Organised by {creator?.firstName} {creator?.lastName}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => updateStatusMutation.mutate('scheduled')}
+              disabled={updateStatusMutation.isPending}
+            >
+              Scheduled
+            </Button>
+            <Button
+              onClick={() => updateStatusMutation.mutate('open')}
+              disabled={updateStatusMutation.isPending}
+            >
+              Open
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => updateStatusMutation.mutate('closed')}
+              disabled={updateStatusMutation.isPending}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Card>
+            <CardContent className="p-5 text-center">
+              <p className="text-sm text-muted-foreground">Present</p>
+              <p className="text-3xl font-bold text-foreground">{counts.present ?? 0}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-5 text-center">
+              <p className="text-sm text-muted-foreground">Excused</p>
+              <p className="text-3xl font-bold text-foreground">{counts.excused ?? 0}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-5 text-center">
+              <p className="text-sm text-muted-foreground">Absent</p>
+              <p className="text-3xl font-bold text-foreground">{counts.absent ?? 0}</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Mark attendance</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {myResponse && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <CheckCircle2 className="text-success" size={16} />
+                You have marked yourself as <span className="font-semibold text-foreground">{myResponse}</span>.
+              </div>
+            )}
+
+            <Textarea
+              placeholder="Add an optional note (e.g., reason for absence)"
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+            />
+
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Button
+                className="flex-1"
+                onClick={() => markAttendanceMutation.mutate('present')}
+                disabled={markAttendanceMutation.isPending}
+              >
+                I'm present
+              </Button>
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={() => markAttendanceMutation.mutate('excused')}
+                disabled={markAttendanceMutation.isPending}
+              >
+                Excused
+              </Button>
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => markAttendanceMutation.mutate('absent')}
+                disabled={markAttendanceMutation.isPending}
+              >
+                Absent
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Attendance responses</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {(summary?.records ?? []).length === 0 ? (
+              <p className="text-sm text-muted-foreground">No responses yet.</p>
+            ) : (
+              <div className="space-y-3">
+                {(summary?.records ?? []).map((record) => (
+                  <div
+                    key={record.id}
+                    className="border border-border rounded-lg p-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
+                  >
+                    <div>
+                      <p className="font-medium text-foreground">
+                        {record.firstName} {record.lastName}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{record.email}</p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <Badge className="capitalize">{record.response}</Badge>
+                      {record.note && (
+                        <span className="text-xs text-muted-foreground max-w-sm">{record.note}</span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/attendance.tsx
+++ b/client/src/pages/attendance.tsx
@@ -1,0 +1,91 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { NavigationHeader } from "@/components/navigation-header";
+import { AttendanceCard } from "@/components/attendance-card";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CalendarPlus, UsersRound } from "lucide-react";
+import type { AttendanceSession, User } from "@shared/schema";
+
+type AttendanceWithCreator = AttendanceSession & {
+  creator?: Pick<User, "firstName" | "lastName"> | null;
+};
+
+export default function Attendance() {
+  const { data: openSessions } = useQuery<AttendanceWithCreator[]>({
+    queryKey: ['/api/attendance/status/open'],
+  });
+
+  const { data: scheduledSessions } = useQuery<AttendanceWithCreator[]>({
+    queryKey: ['/api/attendance/status/scheduled'],
+  });
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationHeader />
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-10">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">Attendance Sessions</h1>
+            <p className="text-muted-foreground">Track member participation for meetings and events</p>
+          </div>
+          <Link href="/create-attendance">
+            <Button className="bg-primary text-primary-foreground" data-testid="button-new-attendance">
+              <CalendarPlus size={16} className="mr-2" />
+              New Attendance Session
+            </Button>
+          </Link>
+        </div>
+
+        <section className="space-y-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-semibold text-foreground">Open Sessions</h2>
+            <p className="text-sm text-muted-foreground flex items-center gap-2">
+              <UsersRound size={14} />
+              Members can submit their attendance while sessions are open.
+            </p>
+          </div>
+
+          {openSessions && openSessions.length > 0 ? (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {openSessions.map((session) => (
+                <AttendanceCard key={session.id} session={session} />
+              ))}
+            </div>
+          ) : (
+            <Card className="border-dashed">
+              <CardContent className="py-10 text-center space-y-3">
+                <CalendarPlus className="mx-auto text-muted-foreground" size={36} />
+                <p className="text-lg font-semibold text-foreground">No open sessions right now</p>
+                <p className="text-sm text-muted-foreground">
+                  Create a new attendance session to start capturing participation.
+                </p>
+                <Link href="/create-attendance">
+                  <Button className="bg-primary text-primary-foreground">Create session</Button>
+                </Link>
+              </CardContent>
+            </Card>
+          )}
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-2xl font-semibold text-foreground">Upcoming</h2>
+          {scheduledSessions && scheduledSessions.length > 0 ? (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {scheduledSessions.map((session) => (
+                <AttendanceCard key={session.id} session={session} />
+              ))}
+            </div>
+          ) : (
+            <Card>
+              <CardContent className="py-8 text-center text-muted-foreground">
+                No scheduled sessions.
+              </CardContent>
+            </Card>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/create-attendance.tsx
+++ b/client/src/pages/create-attendance.tsx
@@ -1,0 +1,171 @@
+import { useLocation } from "wouter";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { NavigationHeader } from "@/components/navigation-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+
+const attendanceSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().optional(),
+  meetingDate: z.string().min(1, "Meeting date is required"),
+  status: z.enum(['scheduled', 'open', 'closed']).default('open'),
+});
+
+type AttendanceFormData = z.infer<typeof attendanceSchema>;
+
+export default function CreateAttendance() {
+  const [, setLocation] = useLocation();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const form = useForm<AttendanceFormData>({
+    resolver: zodResolver(attendanceSchema),
+    defaultValues: {
+      title: "",
+      description: "",
+      meetingDate: new Date().toISOString().slice(0, 16),
+      status: 'open',
+    },
+  });
+
+  const createAttendanceMutation = useMutation({
+    mutationFn: async (data: AttendanceFormData) => {
+      const payload = {
+        ...data,
+        meetingDate: new Date(data.meetingDate).toISOString(),
+      };
+      await apiRequest('POST', '/api/attendance', payload);
+    },
+    onSuccess: () => {
+      toast({
+        title: "Attendance session created",
+        description: "Members can now mark their attendance.",
+      });
+      queryClient.invalidateQueries({ queryKey: ['/api/attendance/status/open'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/attendance/status/scheduled'] });
+      setLocation('/attendance');
+    },
+    onError: (err: Error) => {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to create attendance session",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: AttendanceFormData) => {
+    createAttendanceMutation.mutate(data);
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationHeader />
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-foreground mb-2">Create Attendance Session</h1>
+          <p className="text-muted-foreground">Capture attendance for meetings, events, and more.</p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Session details</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Session title *</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g., Weekly Chapter Meeting" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Add context or agenda items..."
+                          rows={4}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="meetingDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meeting date *</FormLabel>
+                      <FormControl>
+                        <Input type="datetime-local" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="status"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Status</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select status" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="scheduled">Scheduled</SelectItem>
+                          <SelectItem value="open">Open</SelectItem>
+                          <SelectItem value="closed">Closed</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <div className="flex justify-end gap-3">
+                  <Button type="button" variant="outline" onClick={() => setLocation('/attendance')}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={createAttendanceMutation.isPending}>
+                    Create session
+                  </Button>
+                </div>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/results.tsx
+++ b/client/src/pages/results.tsx
@@ -66,6 +66,9 @@ export default function Results() {
   const creator = vote.creator;
   const totalVotes = participation?.totalVotes || 0;
   const participationRate = totalVotes > 0 ? Math.round((totalVotes / 42) * 100) : 0;
+  const multipleChoiceOptions = Array.isArray(voteData.options)
+    ? (voteData.options as string[])
+    : [];
 
   return (
     <div className="min-h-screen bg-background">
@@ -193,9 +196,9 @@ export default function Results() {
                     </>
                   )}
                   
-                  {voteData.type === 'multiple_choice' && voteData.options && Array.isArray(voteData.options) && (
+                  {voteData.type === 'multiple_choice' && multipleChoiceOptions.length > 0 && (
                     <>
-                      {(voteData.options as string[]).map((option: string, index: number) => {
+                      {multipleChoiceOptions.map((option: string, index: number) => {
                         const optionVotes = results.filter((r: any) => r.choices?.selectedOption === option).length;
                         const percentage = totalVotes > 0 ? Math.round((optionVotes / totalVotes) * 100) : 0;
                         


### PR DESCRIPTION
## Summary
- add database schema and backend storage/routes to support attendance sessions and records
- introduce attendance management UI with dashboard list, session detail, and creation form
- surface attendance status in the navigation and home dashboard alongside existing vote metrics

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e5304f6b988324951c4644dd6405da